### PR TITLE
Added steps for installing and configuring Dagster pipelines

### DIFF
--- a/dagster/config.sls
+++ b/dagster/config.sls
@@ -1,15 +1,16 @@
-{% from "dagster/map.jinja" import dagster with context %}
+#!pyobjects
+#~*~ mode: Python ~*~
+import yaml
 
-include:
-  - .install
-  - .service
+dagster = salt.jinja.load_map('dagster/map.jinja', 'dagster')
 
-dagster-config:
-  file.managed:
-    - name: {{ dagster.conf_file }}
-    - source: salt://dagster/templates/conf.jinja
-    - template: jinja
-    - watch_in:
-      - service: dagster_service_running
-    - require:
-      - pkg: dagster
+include('.service')
+
+File.managed(
+    'dagster_configuration_file',
+    name='{0}/dagster.yaml'.format(dagster['home']),
+    contents=yaml.dump(dagster['config']['instance'], default_flow_style=False),
+    user=dagster['user'],
+    group=dagster['group'],
+    onchanges_in=[Service('dagster_service_running')]
+)

--- a/dagster/install.sls
+++ b/dagster/install.sls
@@ -1,10 +1,52 @@
-{% from "dagster/map.jinja" import dagster with context %}
+#!pyobjects
+#~*~ mode: Python ~*~
 
-include:
-  - .service
+dagster = salt.jinja.load_map('dagster/map.jinja', 'dagster')
 
-dagster:
-  pkg.installed:
-    - pkgs: {{ dagster.pkgs }}
-    - require_in:
-        - service: dagster_service_running
+include('.service')
+
+User.present(
+    'create_dagster_user',
+    name=dagster['user'],
+    home=dagster['home'],
+    require_in=Service('dagster_service_running')
+)
+
+Group.present(
+    'create_dagster_group',
+    name=dagster['group'],
+    require_in=Service('dagster_service_running')
+)
+
+Pkg.installed(
+    'install_dagit_and_dagster_packages',
+    sources=dagster['pkg_sources'],
+    require_in=Service('dagster_service_running')
+)
+
+File.managed(
+    'create_dagit_control_script',
+    name='/usr/local/bin/dagit.sh',
+    template='jinja',
+    source='salt://dagster/templates/dagit.sh.j2',
+    context={
+        'dagit_path': dagster['dagit']['path'],
+        'dagit_port': dagster['dagit']['port'],
+        'dagit_listen_address': dagster['dagit']['listen_address'],
+        'dagit_flags': dagster['dagit']['flags']
+    },
+    mode='0755'
+)
+
+File.managed(
+    'create_dagit_systemd_unit',
+    name='/etc/systemd/system/dagit.service',
+    template='jinja',
+    source='salt://dagster/templates/dagster.service.j2',
+    context={
+        'user': dagster['user'],
+        'dagster_home': dagster['home']
+    },
+    require=File('create_dagit_control_script'),
+    require_in=Service('dagster_service_running')
+)

--- a/dagster/map.jinja
+++ b/dagster/map.jinja
@@ -1,11 +1,21 @@
 {% set dagster = salt.grains.filter_by({
     'default': {
-        'pkgs': ['dagster'],
-        'service': 'dagster',
-        'conf_file': '/etc/dagster/dagster.conf',
+        'service': 'dagit',
+        'home': '/opt/dagster/',
+        'user': 'dagster',
+        'group': 'dagster',
         'config': {
-            'key': 'value',
+            'instance': {
+            }
         },
+        'dagit': {
+            'path': '/usr/local/bin/',
+            'port': 3000,
+            'listen_address': '0.0.0.0',
+            'flags': [
+                '-w workspace.yaml'
+            ]
+        }
     },
     'Debian': {
     },

--- a/dagster/tests/test_install.sls
+++ b/dagster/tests/test_install.sls
@@ -1,8 +1,2 @@
 {% from "dagster/map.jinja" import dagster with context %}
 
-{% for pkg in dagster.pkgs %}
-test_{{pkg}}_is_installed:
-  testinfra.package:
-    - name: {{ pkg }}
-    - is_installed: True
-{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,16 @@
 # -*- mode: yaml -*-
 dagster:
-  overrides:
-    pkg: dagster
-    conf_file: /usr/local/etc/dagster/dagster.conf
+  home: /opt/ol_data_pipelines
+  dagit:
+    path: /opt/ol_data_pipelines/bin
+    flags: -w etc/workspace.yaml
   config:
-    key: othervalue
+    instance:
+      dagit:
+      run_storage:
+        module: dagster.core.storage.runs
+        class: SqliteRunStorage
+        config:
+          base_dir: /opt/dagster/
+  pkg_sources:
+    - ol-data-pipelines: https://ol-eng-artifacts.s3.amazonaws.com/ol-data-pipelines/ol-data-pipelines_0.1.0_amd64.deb

--- a/salt-top.example
+++ b/salt-top.example
@@ -1,6 +1,4 @@
 base:
   '*':
     - dagster
-    
     - dagster.tests
-    


### PR DESCRIPTION
This relies on the pipeline code and dagster/dagit executables being packaged via vdist and installed using the OS package manager